### PR TITLE
[Improvement] Adding status filter when listing addons

### DIFF
--- a/src/Api/Addons/Addon.php
+++ b/src/Api/Addons/Addon.php
@@ -19,6 +19,9 @@ class Addon extends AbstractApi
     {
         $resolver = $this->createOptionsResolver();
 
+        $resolver->setDefined('status[is]')
+            ->setAllowedTypes('status[is]', 'string');
+
         $url = $this->url('addons');
 
         return $this->get($url, $resolver->resolve($parameters), $headers);


### PR DESCRIPTION
We need to be able to filter addons by their status, otherwise they are returned in addons search on the API